### PR TITLE
Pass User actor to versioning

### DIFF
--- a/lib/vestal_versions/users.rb
+++ b/lib/vestal_versions/users.rb
@@ -15,10 +15,12 @@ module VestalVersions
 
     private
     # Adds version user attribution, preferring explicit +updated_by+ and
-    # falling back to +config.change_user_actor+ when available.
+    # falling back to +config.retrieve_user_actor+ when available.
     # Only ActiveRecord actors are accepted.
     def version_attributes
-      user_actor = updated_by || VestalVersions.config.change_user_actor&.call(self)
+      resolver = VestalVersions.config.retrieve_user_actor
+      resolved_actor = resolver&.arity == 0 ? resolver.call : resolver&.call(self)
+      user_actor = updated_by || resolved_actor
 
       user_actor = nil unless user_actor.is_a?(ActiveRecord::Base)
 

--- a/lib/vestal_versions/users.rb
+++ b/lib/vestal_versions/users.rb
@@ -14,10 +14,19 @@ module VestalVersions
 
 
     private
-    # Overrides the +version_attributes+ method to include user information passed into the
-    # parent object, by way of a +updated_by+ attr_accessor.
+    # Adds version user attribution, preferring explicit +updated_by+ and
+    # falling back to +config.change_user_actor+ when available.
+    # Only ActiveRecord actors are accepted.
     def version_attributes
-      super.merge(:user => updated_by)
+      user_actor = updated_by
+      if user_actor.nil?
+        resolver = VestalVersions.config.change_user_actor
+        user_actor = resolver&.call(self)
+      end
+
+      user_actor = nil unless user_actor.is_a?(ActiveRecord::Base)
+
+      super.merge(:user => user_actor)
     end
   end
 

--- a/lib/vestal_versions/users.rb
+++ b/lib/vestal_versions/users.rb
@@ -18,11 +18,7 @@ module VestalVersions
     # falling back to +config.change_user_actor+ when available.
     # Only ActiveRecord actors are accepted.
     def version_attributes
-      user_actor = updated_by
-      if user_actor.nil?
-        resolver = VestalVersions.config.change_user_actor
-        user_actor = resolver&.call(self)
-      end
+      user_actor = updated_by || VestalVersions.config.change_user_actor&.call(self)
 
       user_actor = nil unless user_actor.is_a?(ActiveRecord::Base)
 

--- a/lib/vestal_versions/version.rb
+++ b/lib/vestal_versions/version.rb
@@ -6,6 +6,7 @@ module VestalVersions
   class Version < ActiveRecord::Base
     include Comparable
     include ActiveSupport::Configurable
+    config_accessor :change_user_actor
 
     # Associate polymorphically with the parent record.
     belongs_to :versioned, :polymorphic => true

--- a/lib/vestal_versions/version.rb
+++ b/lib/vestal_versions/version.rb
@@ -6,7 +6,7 @@ module VestalVersions
   class Version < ActiveRecord::Base
     include Comparable
     include ActiveSupport::Configurable
-    config_accessor :change_user_actor
+    config_accessor :retrieve_user_actor
 
     # Associate polymorphically with the parent record.
     belongs_to :versioned, :polymorphic => true

--- a/spec/vestal_versions/users_spec.rb
+++ b/spec/vestal_versions/users_spec.rb
@@ -18,4 +18,12 @@ describe VestalVersions::Users do
     user.update(:first_name => 'Stephen', :updated_by => updated_by.name)
     expect(user.versions.last.user).to eq(updated_by.name)
   end
+
+  it 'uses change_user_actor when updated_by is nil' do
+    VestalVersions.config.change_user_actor = ->(_record){ updated_by }
+
+    user.update(:first_name => 'Stephen')
+
+    expect(user.versions.last.user).to eq(updated_by)
+  end
 end

--- a/spec/vestal_versions/users_spec.rb
+++ b/spec/vestal_versions/users_spec.rb
@@ -19,8 +19,8 @@ describe VestalVersions::Users do
     expect(user.versions.last.user).to eq(updated_by.name)
   end
 
-  it 'uses change_user_actor when updated_by is nil' do
-    VestalVersions.config.change_user_actor = ->(_record){ updated_by }
+  it 'uses retrieve_user_actor when updated_by is nil' do
+    VestalVersions.config.retrieve_user_actor = ->(_record){ updated_by }
 
     user.update(:first_name => 'Stephen')
 


### PR DESCRIPTION
We aren't capturing user_id in versioning. We need to pass this ID globally where versioning is used.