### PR TITLE
BUG: remove retrieve_user_actor key from options before passing

### DIFF
--- a/lib/vestal_versions/options.rb
+++ b/lib/vestal_versions/options.rb
@@ -30,6 +30,7 @@ module VestalVersions
 
         class_attribute :vestal_versions_options
         self.vestal_versions_options = options.dup
+        options.delete(:retrieve_user_actor)
 
         options.merge!(
           :as => :versioned,

--- a/lib/vestal_versions/users.rb
+++ b/lib/vestal_versions/users.rb
@@ -18,7 +18,7 @@ module VestalVersions
     # falling back to +config.retrieve_user_actor+ when available.
     # Only ActiveRecord actors are accepted.
     def version_attributes
-      resolver = VestalVersions.config.retrieve_user_actor
+      resolver = vestal_versions_options[:retrieve_user_actor]
       resolved_actor = resolver&.arity == 0 ? resolver.call : resolver&.call(self)
       user_actor = updated_by || resolved_actor
 


### PR DESCRIPTION
When `has_many :versions, **options `is called, `:retrieve_user_actor `passed as an invalid option. Delete `retriever_user_actor` from options.